### PR TITLE
Add request retries for some worker calls

### DIFF
--- a/lib/helpers/worker.js
+++ b/lib/helpers/worker.js
@@ -33,7 +33,6 @@
  * limitations under the License.
  */
 
-
 'use strict';
 
 const Bluebird = require('bluebird');
@@ -55,6 +54,19 @@ const tar = require('tar-fs');
 
 function id() {
 	return `${Math.random().toString(36).substring(2, 10)}`;
+}
+
+async function doRequest(options, tries = 5, interval = 1000 * 2) {
+	await retry(
+		async () => {
+			await rp(options);
+		},
+		{
+			max_tries: tries,
+			interval: interval,
+			throw_original: true,
+		}
+	)
 }
 
 export class Worker {
@@ -175,14 +187,14 @@ export class Worker {
 	 */
 	async on() {
 		this.logger.log('Powering on DUT');
-		await rp.post(`${this.url}/dut/on`);
+		await doRequest({method: 'POST', uri: `${this.url}/dut/on`});
 		this.logger.log('DUT powered on');
 	}
 
 	async fetchSerial() {
 		this.logger.log('Pulling Serial logs from DUT');
 		// Logs received were encoding 'UTF-16LE', hence need to convert them right here.
-		return Buffer.from(await rp.get(
+		return Buffer.from(await doRequest(
 				`${this.url}/dut/serial`),
 				'utf-8'
 			).toString();
@@ -195,18 +207,21 @@ export class Worker {
 	 */
 	async off() {
 		this.logger.log('Powering off DUT');
-		await rp.post(`${this.url}/dut/off`);
+		await doRequest({method: 'POST', uri: `${this.url}/dut/on`});
+		this.logger.log('DUT powered off');
 	}
 
 	/**
 	 * Gather diagnostics from testbot
 	 */
 	async diagnostics() {
-		return JSON.parse(await rp.get(`${this.url}/dut/diagnostics`));
+		return JSON.parse(
+			await doRequest({uri: `${this.url}/dut/diagnostics`})
+		);
 	}
 
 	async network(network) {
-		await rp.post({
+		await doRequest({
 			uri: `${this.url}/dut/network`,
 			body: network,
 			json: true,
@@ -214,14 +229,14 @@ export class Worker {
 	}
 
 	proxy(proxy) {
-		return rp.post({ uri: `${this.url}/proxy`, body: proxy, json: true });
+		return doRequest({ method: 'POST', uri: `${this.url}/proxy`, body: proxy, json: true });
 	}
 
 	async getDutIp(
 		target,
 		timeout = {
 			interval: 1000,
-			tries: 120,
+			tries: 30,
 		},
 	) {
 		return retry(
@@ -250,17 +265,17 @@ export class Worker {
 	}
 
 	async teardown() {
-		await rp.post({ uri: `${this.url}/teardown`, json: true });
+		await doRequest({ method: 'POST', uri: `${this.url}/teardown`, json: true });
 	}
 
 	async getContract() {
-		return rp.get({ uri: `${this.url}/contract`, json: true });
+		return doRequest({ method: 'GET', uri: `${this.url}/contract`, json: true });
 	}
 
 	async capture(action) {
 		switch (action) {
 			case 'start':
-				return rp.post({ uri: `${this.url}/dut/capture`, json: true });
+				return doRequest({ method: 'POST', uri: `${this.url}/dut/capture`, json: true });
 			case 'stop':
 				// have to receive tar.gz and unpack them? then return path to directory for the test to consume
 				let capture = request.get({ uri: `${this.url}/dut/capture` });
@@ -657,7 +672,7 @@ export class Worker {
 	async archiveLogs(
 		title,
 		target,
-		command = 'journalctl --no-pager --no-hostname -a -b all',
+		command = "journalctl --no-pager --no-hostname --list-boots | awk '{print $1}' | xargs -I{} sh -c 'set -x; journalctl --no-pager --no-hostname -a -b {} || true;'",
 	) {
 		const logFilePath = `/tmp/${command.split(' ')[0]}-${id()}.log`;
 		this.logger.log(
@@ -667,7 +682,7 @@ export class Worker {
 			const commandOutput = await this.executeCommandInHostOS(
 				`${command}`,
 				target,
-				{ interval: 10000, tries: 3 },
+				{ interval: 5000, max_tries: 3 },
 			);
 			fs.writeFileSync(logFilePath, commandOutput);
 			await archiver.add(title, logFilePath);
@@ -676,665 +691,3 @@ export class Worker {
 		}
 	}
 };
-
-
-// import retry from 'bluebird-retry';
-// import request from 'request';
-// import rp from 'request-promise';
-// import { fs } from 'mz';
-// import * as Stream from 'stream';
-// import { once, isNumber } from 'lodash';
-// import { promisify } from 'util';
-// import {exec as Exec, spawn} from 'child_process';
-// import { utils } from './utils';
-// import * as archiver from './archiver';
-// import { createGzip, createGunzip } from 'zlib';
-// import tar from 'tar-fs';
-// import path from 'path';
-
-// const pipeline = promisify(Stream.pipeline);
-// const exec = promisify(Exec);
-
-// function id() {
-// 	return `${Math.random()
-// 		.toString(36)
-// 		.substring(2, 10)}`;
-// }
-
-// export class Worker {
-// 	url: string;
-// 	logger: any;
-// 	deviceType: string;
-// 	username: any;
-// 	sshKey: any;
-// 	dutSshKey: string;
-// 	workerHost: string;
-// 	workerPort: string;
-// 	workerUser: string;
-// 	sshPrefix: string;
-// 	uuid: string;
-// 	directConnect: boolean;
-
-// 	constructor(
-// 		deviceType: string,
-// 		logger = { log: console.log, status: console.log, info: console.log },
-// 		url: string,
-// 		username: any,
-// 		sshKey: any,
-// 	) {
-// 		this.deviceType = deviceType
-// 		this.url = url;
-// 		this.logger = logger;
-// 		this.username = username;
-// 		this.sshKey = sshKey;
-// 		this.dutSshKey = `/tmp/id`;
-// 		this.logger = logger;
-// 		this.workerHost = new URL(this.url).hostname;
-// 		this.workerPort = '22222';
-// 		this.workerUser = 'root';
-// 		this.sshPrefix = '';
-// 		this.uuid = '';
-// 		this.directConnect = (
-// 			this.url.includes(`worker`)
-// 			|| this.url.includes('unix:')
-// 		);
-// 		if (this.url.includes(`balena-devices.com`)) {
-// 			// worker is a testbot connected to balena cloud - we ssh into it via the vpn
-// 			this.uuid = this.url.match(
-// 				/(?<=https:\/\/)(.*)(?=.balena-devices.com)/,
-// 			)![1];
-// 			this.workerHost = `ssh.balena-devices.com`;
-// 			this.workerUser = this.username;
-// 			this.workerPort = '22';
-// 			this.sshPrefix = `host ${this.uuid} `;
-// 		}
-// 	}
-
-// 	/**
-// 	 * Flash the provided OS image onto the connected DUT
-// 	 *
-// 	 * @param {string} imagePath path of the image to be flashed onto the DUT
-// 	 *
-// 	 * @category helper
-// 	 */
-// 	async flash(imagePath: string) {
-// 		let attempt = 0;
-// 		await retry(
-// 			async () => {
-// 				attempt++;
-// 				this.logger.log(`Preparing to flash, attempt ${attempt}...`);
-
-// 				await new Promise<void>(async (resolve, reject): Promise<void> => {
-// 					const req = rp.post({ uri: `${this.url}/dut/flash` });
-
-// 					req.catch((error) => {
-// 						reject(error);
-// 					});
-// 					req.finally(() => {
-// 						if (lastStatus !== 'done') {
-// 							reject(new Error('Unexpected end of TCP connection'));
-// 						}
-
-// 						resolve();
-// 					});
-
-// 					let lastStatus: string;
-// 					req.on('data', (data) => {
-// 						const computedLine = RegExp('(.+?): (.*)').exec(data.toString());
-
-// 						if (computedLine) {
-// 							if (computedLine[1] === 'error') {
-// 								req.cancel();
-// 								reject(new Error(computedLine[2]));
-// 							}
-
-// 							if (computedLine[1] === 'progress') {
-// 								once(() => {
-// 									this.logger.log('Flashing');
-// 								});
-// 								// Hide any errors as the lines we get can be half written
-// 								const state = JSON.parse(computedLine[2]);
-// 								if (state != null && isNumber(state.percentage)) {
-// 									this.logger.status({
-// 										message: 'Flashing',
-// 										percentage: state.percentage,
-// 									});
-// 								}
-// 							}
-
-// 							if (computedLine[1] === 'status') {
-// 								lastStatus = computedLine[2];
-// 							}
-// 						}
-// 					});
-
-// 					pipeline(
-// 						fs.createReadStream(imagePath),
-// 						createGzip({ level: 6 }),
-// 						await req,
-// 					);
-// 				});
-// 				this.logger.log('Flash completed');
-// 			},
-// 			{
-// 				max_tries: 5,
-// 				interval: 1000 * 5,
-// 				throw_original: true,
-// 			},
-// 		);
-// 	}
-
-// 	/**
-// 	 * Turn the DUT on
-// 	 *
-// 	 * @category helper
-// 	 */
-// 	async on() {
-// 		this.logger.log('Powering on DUT');
-// 		await rp.post(`${this.url}/dut/on`);
-// 		this.logger.log('DUT powered on');
-// 	}
-
-// 	async fetchSerial() {
-// 		this.logger.log('Pulling Serial logs from DUT');
-// 		// Logs received were encoding 'UTF-16LE', hence need to convert them right here.
-// 		return Buffer.from(await rp.get(
-// 				`${this.url}/dut/serial`),
-// 				'utf-8'
-// 			).toString();
-// 	}
-
-// 	/**
-// 	 * Turn the DUT off
-// 	 *
-// 	 * @category helper
-// 	 */
-// 	async off() {
-// 		this.logger.log('Powering off DUT');
-// 		await rp.post(`${this.url}/dut/off`);
-// 	}
-
-// 	/**
-// 	 * Gather diagnostics from testbot
-// 	 */
-// 	 async diagnostics() {
-// 		return JSON.parse(await rp.get(`${this.url}/dut/diagnostics`));
-// 	}
-
-// 	async network(network: any) {
-// 		await rp.post({
-// 			uri: `${this.url}/dut/network`,
-// 			body: network,
-// 			json: true,
-// 		});
-// 	}
-
-// 	proxy(proxy: any) {
-// 		return rp.post({ uri: `${this.url}/proxy`, body: proxy, json: true });
-// 	}
-
-// async getDutIp(
-// 		target:string,
-// 		timeout = {
-// 			interval: 1000,
-// 			tries: 120,
-// 		},
-// 	) {
-// 		return retry(
-// 			() => {
-// 				return rp.get({
-// 					uri: `${this.url}/dut/ip`,
-// 					body: { target },
-// 					json: true,
-// 				});
-// 			},
-// 			{
-// 				max_tries: timeout.tries,
-// 				interval: timeout.interval,
-// 				throw_original: true,
-// 			},
-// 		);
-// 	}
-
-// 	async ip(target: string) {
-// 		// ip of DUT - used to talk to it
-// 		// if testbot/local testbot, then we dont wan't the ip, as we use SSH tunneling to talk to it - so return 127.0.0.1
-// 		// if qemu, return the ip - as we talk to the DUT directly
-// 		return this.directConnect
-// 			? this.getDutIp(target)
-// 			: Promise.resolve(`127.0.0.1`);
-// 	}
-
-
-// 	async teardown() {
-// 		await rp.post({ uri: `${this.url}/teardown`, json: true });
-// 	}
-
-
-// 	async getContract() {
-// 		return rp.get({ uri: `${this.url}/contract`, json: true });
-// 	}
-
-// 	async capture(action: string) {
-// 		switch (action) {
-// 			case 'start':
-// 				return rp.post({ uri: `${this.url}/dut/capture`, json: true });
-// 			case 'stop':
-// 				// have to receive tar.gz and unpack them? then return path to directory for the test to consume
-// 				let capture: any = request.get({ uri: `${this.url}/dut/capture` });
-// 				return pipeline(capture, createGunzip(), tar.extract('/tmp/capture'));
-// 		}
-// 	}
-
-// 	/**
-// 	 * Executes command-line operations in the host OS of the DUT. Assuming the DUT is
-// 	 * connected to the access point broadcasted by the testbot:
-// 	 *
-// 	 * @example
-// 	 * ```js
-// 	 * const Worker = this.require('common/worker');
-// 	 * const worker = new Worker(DEVICE_TYPE_SLUG, this.getLogger())
-// 	 * await worker.executeCommandInHostOS('cat /etc/hostname', `${UUID}.local`);
-// 	 * await worker.executeCommandInHostOS(
-// 	 *   ['jq', `'.hostname=${newHostname}'`, '/mnt/boot/config.json'], `${UUID}.local`
-// 	 * );
-// 	 * ```
-// 	 *
-// 	 * @param {string | Array} command command to be executed on the DUT, arrays are joined by spaces
-// 	 * @param {string} target local UUID of the DUT, example:`${UUID}.local`
-// 	 * @param {{"interval": number, "tries": number}} timeout object containing details of how many times the
-// 	 * command needs to be retried and the intervals between each command execution
-// 	 * @returns {string} Output of the command that was exected on hostOS of the DUT
-// 	 *
-// 	 * @category helper
-// 	 */
-// 	async executeCommandInHostOS(command: string | Array<any>, target: string, retryOptions={}): Promise<string> {
-// 		const sshCommand = command instanceof Array ? command.join(' ') : command;
-// 		let config = {};
-// 		// depending on if the target argument is a .local uuid or not, SSH via the proxy or directly
-// 		if (/.*\.local/.test(target)) {
-// 			let ip = await this.ip(target);
-// 			config = {
-// 				host: ip,
-// 				port: '22222',
-// 				username: 'root',
-// 			};
-// 		} else {
-// 			config = {
-// 				host: 'ssh.balena-devices.com',
-// 				port: '22',
-// 				username: this.username,
-// 			};
-// 			command = `host ${target} ${command}`;
-// 		}
-
-// 		return retry(
-// 			async () => {
-// 				let result: any = {}
-// 				try {
-// 					result = await utils.executeCommandOverSSH(sshCommand, config);
-// 				} catch (err: any) {
-// 					console.error(err.message);
-// 					throw new Error(err);
-// 				}
-
-// 				if (typeof result.code === 'number' && result.code !== 0) {
-// 					throw new Error(
-// 						`"${command}" failed. stderr: ${result.stderr}, stdout: ${result.stdout}, code: ${result.code}`,
-// 					);
-// 				}
-
-// 				return result.stdout;
-// 			},
-// 			{
-// 				max_tries: 5 * 60,
-// 				interval: 1000,
-// 				throw_original: true,
-// 				...retryOptions,
-// 			},
-// 		);
-// 	}
-	
-// 	async executeCommandInWorkerHost(command: string, retryOptions={}) {
-// 		let config = {
-// 			host: this.workerHost,
-// 			port: this.workerPort,
-// 			username: this.workerUser,
-// 		}
-
-// 		return retry(
-// 			async () => {
-// 				let result: any = {}
-// 				try {
-// 					result = await utils.executeCommandOverSSH(`${this.sshPrefix}${command}`, config);
-// 				} catch (err: any) {
-// 					console.error(err.message);
-// 					throw new Error(err);
-// 				}
-// 				if (typeof result.code === 'number' && result.code !== 0) {
-// 					throw new Error(
-// 						`"${command}" failed. stderr: ${result.stderr}, stdout: ${result.stdout}, code: ${result.code}`,
-// 					);
-// 				}
-// 				return result.stdout;
-// 			},
-// 			{
-// 				max_tries: 30,
-// 				interval: 5000,
-// 				throw_original: true,
-// 				...retryOptions,
-// 			},
-// 		);
-// 	}
-
-// 	// executes command in the worker container
-// 	async executeCommandInWorker(command: string, retryOptions={}) {
-// 		return retry(
-// 			async () => {
-// 				let containerId = await this.executeCommandInWorkerHost(
-// 					`balena ps | grep worker | awk '{print $1}'`,
-// 				);
-// 				let result = await this.executeCommandInWorkerHost(
-// 					`balena exec ${containerId} ${command}`,
-// 				);
-// 				return result;
-// 			},
-// 			{
-// 				max_tries: 10,
-// 				interval: 1000,
-// 				throw_original: true,
-// 				...retryOptions,
-// 			},
-// 		);
-// 	}
-
-// 	// creates a tunnel a specified DUT port
-// 	async createTunneltoDUT(target: string, dutPort: number, workerPort: number) {
-
-// 		//get containerID of the worker container on the testbot - we must do socat from inside the worker container
-// 		let containerId = await this.executeCommandInWorkerHost(
-// 			`balena ps | grep worker | awk '{print $1}'`,
-// 		);
-
-// 		let ip = await this.getDutIp(target);
-// 		let argsWorker: any[] = [];
-// 		argsWorker = argsWorker.concat([
-// 			`${this.workerUser}@${this.workerHost}`,
-// 			`-p`,
-// 			this.workerPort,
-// 			'-i',
-// 			this.sshKey,
-// 			`-o`,
-// 			`StrictHostKeyChecking=no`,
-// 			`-o`,
-// 			`UserKnownHostsFile=/dev/null`,
-// 		]);
-
-// 		if (this.sshPrefix !== '') {
-// 			argsWorker = argsWorker.concat([`host`, this.uuid]);
-// 		}
-
-// 		argsWorker = argsWorker.concat([
-// 			`balena`,
-// 			`exec`,
-// 			containerId,
-// 			`socat`,
-// 			`tcp-listen:${workerPort},reuseaddr,fork "system:ssh ${ip} -p 22222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${this.dutSshKey} /usr/bin/nc localhost ${dutPort}"`,
-// 		]);
-
-// 		// @ts-ignore
-// 		let tunnelProWorker = spawn(`ssh`, argsWorker);
-
-// 		// setup a listener from this host to worker must be a sub process...
-// 		// we must give map the same port on this host and the DUT - so the cli can use it
-// 		// this will be torn down at the end of the tests when the core is destroyed
-// 		let argsClient = [
-// 			`tcp-listen:${dutPort},reuseaddr,fork`,
-// 			`system:ssh ${this.workerUser}@${this.workerHost} -p ${this.workerPort} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${this.sshKey} ${this.sshPrefix}/usr/bin/nc localhost ${workerPort}`,
-// 		];
-
-// 		// @ts-ignore
-// 		let tunnelProcClient = spawn(`socat`, argsClient);
-// 	}
-
-// 	// create tunnels to relevant DUT ports to we can access them remotely
-// 	async createSSHTunnels(target: string) {
-// 		if (!this.directConnect) {
-// 			const DUT_PORTS = [
-// 				48484, // supervisor
-// 				22222, // ssh
-// 				2375, // engine
-// 			];
-// 			let workerPort = 8888;
-// 			for (let port of DUT_PORTS) {
-// 				console.log(`creating tunnel to dut port ${port}...`);
-// 				await this.createTunneltoDUT(target, port, workerPort);
-// 				workerPort = workerPort + 1;
-// 			}
-// 		} else {
-// 			// set up route to DUT via the worker ip
-// 			console.log(`Getting ip of dut`)
-// 			let dutIp = await this.ip(target);
-// 			console.log(`getting ip of worker`)
-// 			let workerIp = await exec(`dig +short worker`);
-// 			console.log(`ip route add ${dutIp} via ${workerIp}`)
-// 			// If the route already exists, do not throw an error
-// 			try {
-// 				await exec(`ip route add ${dutIp} via ${workerIp}`)
-// 			} catch (e) {
-// 				console.error(`Failed to add ip route: ${e}`);
-// 			}
-// 		}
-// 	}
-
-// 	// sends file over rsync
-// 	async sendFile(filePath: string, destination: string, target: string) {
-// 		if (target === 'worker') {
-// 			let containerId = await this.executeCommandInWorkerHost(
-// 				`balena ps | grep worker | awk '{print $1}'`,
-// 			);
-// 			// todo : replace with npm package
-// 			await exec(
-// 				`rsync -av -e "ssh ${this.workerUser}@${this.workerHost} -p ${this.workerPort} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q ${this.sshPrefix}balena exec -i" ${filePath} ${containerId}:${destination}`,
-// 			);
-// 		} else {
-// 			let ip = await this.ip(target);
-// 			await exec(
-// 				`rsync -av -e "ssh -p 22222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q -i ${this.sshKey}" ${filePath} root@${ip}:${destination}`,
-// 			);
-// 		}
-// 	}
-
-// 	// add ssh key to the worker, so it can ssh into prod DUT's
-// 	async addSSHKey(keyPath: string) {
-// 		if (!this.directConnect) {
-// 			console.log(`Adding dut ssh key to worker...`);
-// 			const SSH_KEY_PATH = '/tmp/';
-// 			await this.sendFile(keyPath, SSH_KEY_PATH, 'worker');
-// 			await this.sendFile(
-// 				keyPath,
-// 				`${SSH_KEY_PATH}${path.basename(keyPath)}.pub`,
-// 				'worker',
-// 			);
-// 			console.log(`ssh key added!`);
-// 		}
-// 	}
-
-// 	/**
-// 	 * Pushes a release to an application from a given directory for unmanaged devices
-// 	 *
-// 	 * @param {string} target  the <UUID> for the target device
-// 	 * @param {string} source The path to the directory containing the docker-compose/Dockerfile for the containers
-// 	 * @param {string} containerName The name of the container to verify is push has succeeded.
-// 	 * @returns {string} returns state of the device
-// 	 *
-// 	 * @category helper
-// 	 */
-// 	async pushContainerToDUT(target: string, source: string, containerName: string): Promise<string> {
-// 		let ip: any = await this.ip(target);
-// 		await utils.waitUntil(async () => {
-// 			console.log('Waiting for supervisor to be reachable before local push...')
-// 			return (
-// 				(await rp({
-// 					method: 'GET',
-// 					uri: `http://${ip}:48484/ping`,
-// 					timeout: 5000
-// 				})) === 'OK'
-// 			);
-// 		}, false);
-// 		console.log('Pushing container to DUT...')
-// 		await new Promise<void>(async (resolve, reject) => {
-
-// 			const pushTimeout = setTimeout(() => {
-// 				clearTimeout(pushTimeout);
-// 				pushProc.kill();
-// 				reject(Error('Push timed out'));
-// 			}, 1000 * 60 * 10);
-
-// 			let pushProc: any = spawn('balena', [
-// 				'push',
-// 				ip,
-// 				'--source',
-// 				source,
-// 				'--nolive',
-// 				'--detached',
-// 				'--debug'
-// 			], { stdio: 'inherit' });
-
-// 			pushProc.on('exit', (code: number) => {
-// 				if (code === 0) {
-// 					resolve();
-// 				} else {
-// 					reject()
-// 				}
-// 			});
-
-// 			function handleSignal(signal: any) {
-// 				pushProc.kill(signal);
-// 			}
-
-// 			pushProc.on('error', (err: any) => {
-// 				process.off('SIGINT', handleSignal);
-// 				process.off('SIGTERM', handleSignal);
-// 				reject(err);
-// 			});
-
-// 			clearTimeout(pushTimeout);
-// 		});
-
-// 		// now wait for new container to be available
-// 		let state: any = {};
-// 		await utils.waitUntil(async () => {
-// 			console.log(`waiting for container to be available...`)
-// 			state = await rp({
-// 				method: 'GET',
-// 				uri: `http://${ip}:48484/v2/containerId`,
-// 				json: true,
-// 			});
-
-// 			return state.services[containerName] != null;
-// 		}, false);
-// 		return state;
-// 	}
-
-// 	/**
-// 	 * Executes the command in the targeted container of a device
-// 	 * @param {string | Array} command The command to be executed, arrays are joined by spaces
-// 	 * @param {string} containerName The name of the service/container to run the command in
-// 	 * @param {*} target The `<UUID.local>` of the target device
-// 	 * @returns {string} output of the command that is executed on the targetted container of the device
-// 	 * @category helper
-// 	 */
-// 	async executeCommandInContainer(command: string | Array<any>, containerName: string, target: string): Promise<string> {
-// 		let ip = await this.ip(target);
-// 		// get container ID
-// 		const state = await rp({
-// 			method: 'GET',
-// 			uri: `http://${ip}:48484/v2/containerId`,
-// 			json: true,
-// 		});
-
-// 		const stdout = await this.executeCommandInHostOS(
-// 			`balena exec ${state.services[containerName]} ${command instanceof Array ? command.join(' ') : command
-// 			}`,
-// 			target,
-// 		);
-// 		return stdout;
-// 	}
-
-// 	/**
-// 	 * Triggers a reboot on the target device and waits until the device comes back online
-// 	 *
-// 	 * @param {string} target
-// 	 * @category helper
-// 	 */
-// 	async rebootDut(target: string) {
-// 		this.logger.log(`Rebooting the DUT`);
-// 		await this.executeCommandInHostOS(
-// 			`touch /tmp/reboot-check && systemd-run --on-active=2 reboot`,
-// 			target,
-// 		);
-// 		await this.executeCommandInHostOS(
-// 			'[[ ! -f /tmp/reboot-check ]] && echo pass',
-// 			target,
-// 		);
-// 		this.logger.log(`DUT has rebooted & is back online`);
-// 	}
-
-// 	/**
-// 	 * Fetches OS version available on the DUT's `/etc/os-release` file
-// 	 *
-// 	 * @remark This method works entirely on the device though.
-// 	 * @param {string} target
-// 	 * @returns {string} returns OS version
-// 	 * @category helper
-// 	 */
-// 	async getOSVersion(target: string): Promise<string> {
-// 		// Could be used: https://github.com/balena-io/leviathan/blob/master/core/lib/components/balena/sdk.js#L210
-// 		const output = await this.executeCommandInHostOS(
-// 			'cat /etc/os-release',
-// 			target,
-// 		);
-// 		let match = ''
-// 		output.split('\n').every((x) => {
-// 			if (x.startsWith('VERSION=')) {
-// 				match = x.split('=')[1];
-// 				return false;
-// 			}
-// 			return true;
-// 		});
-// 		return match.replace(/"/g, '');
-// 	}
-
-// 	/**
-// 	 * Helper to archive the output of a HostOS command stored inside a file.
-// 	 *
-// 	 * @remark the default command that runs is `journalctl --no-pager --no-hostname -a -b all`
-// 	 * @param {string} title The name of the directory in which logs will be archived. Usuallly
-// 	 * this value is the name of the test suite (Available in the test using `this.id`)
-// 	 * @param {string} target local UUID of the DUT, example:`${UUID}.local`
-// 	 * @param {string} command The command you need to run and store output for.
-// 	 * @category helper
-// 	 */
-// 	async archiveLogs(
-// 		title: string,
-// 		target: string,
-// 		command: string = 'journalctl --no-pager --no-hostname -a -b all',
-// 	) {
-// 		const logFilePath = `/tmp/${command.split(' ')[0]}-${id()}.log`;
-// 		this.logger.log(
-// 			`Retrieving ${command.split(' ')[0]} logs to the file ${logFilePath} ...`,
-// 		);
-// 		try {
-// 			const commandOutput = await this.executeCommandInHostOS(
-// 				`${command}`,
-// 				target,
-// 				{ interval: 10000, tries: 3 },
-// 			);
-// 			fs.writeFileSync(logFilePath, commandOutput);
-// 			await archiver.add(title, logFilePath);
-// 		} catch (e) {
-// 			this.logger.log(`Couldn't retrieve logs with error: ${e}`);
-// 		}
-// 	}
-// };


### PR DESCRIPTION
This should avoid the ETIMEOUT errors we are seeing when testing e2e with GitHub Actions.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/balena-os/leviathan/issues/792